### PR TITLE
fixed admin dan superadmin isu mana yang bisa di akses dan tidak

### DIFF
--- a/app/api/v1/konsultasi/unit-filtered/route.ts
+++ b/app/api/v1/konsultasi/unit-filtered/route.ts
@@ -70,9 +70,10 @@ export async function GET(request: NextRequest) {
         }
 
         // For superadmin, show all data
-        // For non-superadmin, filter by user's units
+        // For non-superadmin, filter by user's units (ids dipakai untuk query + count)
         let query;
-        
+        let ids: number[] = [];
+
         if (isSuperAdmin) {
             console.log('SuperAdmin - showing all data');
             // SuperAdmin gets all data
@@ -128,7 +129,35 @@ export async function GET(request: NextRequest) {
                 });
             }
             
-            // Non-SuperAdmin gets only data from their assigned units
+            // Non-SuperAdmin: ambil konsultasi_id yang punya unit di unit user (2 langkah agar filter pasti jalan)
+            const { data: konsultasiIdsRow, error: idsError } = await supabase
+                .from("konsultasi_unit")
+                .select("konsultasi_id")
+                .in("unit_id", userUnitIds);
+
+            if (idsError) {
+                console.error("Error fetching konsultasi IDs by unit:", idsError);
+                return NextResponse.json(
+                    { error: "Gagal mengambil data konsultasi", details: idsError.message },
+                    { status: 500 }
+                );
+            }
+
+            ids = [...new Set((konsultasiIdsRow || []).map((r: { konsultasi_id: number }) => r.konsultasi_id))];
+            if (ids.length === 0) {
+                return NextResponse.json({
+                    success: true,
+                    data: [],
+                    pagination: {
+                        total: 0,
+                        limit: limit ? parseInt(limit) : 10,
+                        offset: offset ? parseInt(offset) : 0,
+                        hasNext: false,
+                    },
+                    message: "Tidak ada data konsultasi untuk unit yang ditugaskan ke Anda.",
+                });
+            }
+
             query = supabase
                 .from('konsultasi_spbe')
                 .select(`
@@ -137,7 +166,7 @@ export async function GET(request: NextRequest) {
                         id,
                         nama_pic
                     ),
-                    konsultasi_unit!inner(
+                    konsultasi_unit(
                         konsultasi_id,
                         unit_id,
                         unit_penanggungjawab(
@@ -155,7 +184,7 @@ export async function GET(request: NextRequest) {
                         )
                     )
                 `)
-                .in('konsultasi_unit.unit_id', userUnitIds);
+                .in('id', ids);
         }
 
         // Apply sorting
@@ -188,11 +217,11 @@ export async function GET(request: NextRequest) {
                 .from('konsultasi_spbe')
                 .select('*', { count: 'exact', head: true });
         } else {
-            // Count for non-superadmin
+            // Count for non-superadmin (ids sudah dihitung di branch non-superadmin di atas)
             countQuery = supabase
                 .from('konsultasi_spbe')
-                .select('*, konsultasi_unit!inner(unit_id)', { count: 'exact', head: true })
-                .in('konsultasi_unit.unit_id', userUnitIds);
+                .select('*', { count: 'exact', head: true })
+                .in('id', ids);
         }
         
         // Apply same filters to count query

--- a/app/api/v1/users/[id]/route.ts
+++ b/app/api/v1/users/[id]/route.ts
@@ -123,21 +123,27 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const { full_name, phone, email, password, nip, jabatan, satuan_kerja, instansi, unit_id } = body;
+    const { full_name, phone, email, password, role, nip, jabatan, satuan_kerja, instansi, unit_id } = body;
+
+    // Build update object; role hanya di-update jika dikirim (user | pic | admin)
+    const profileUpdate: Record<string, unknown> = {
+      full_name,
+      phone,
+      email,
+      nip,
+      jabatan,
+      satuan_kerja,
+      instansi,
+      updated_at: new Date().toISOString()
+    };
+    if (role === 'admin' || role === 'pic' || role === 'user') {
+      profileUpdate.role = role;
+    }
 
     // Update profile
     const { data: updatedProfile, error: updateError } = await supabase
       .from('profiles')
-      .update({
-        full_name,
-        phone,
-        email,
-        nip,
-        jabatan,
-        satuan_kerja,
-        instansi,
-        updated_at: new Date().toISOString()
-      })
+      .update(profileUpdate)
       .eq('id', id)
       .select()
       .single();

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -63,6 +63,7 @@ export async function GET(request: NextRequest) {
         jabatan,
         satuan_kerja,
         instansi,
+        role,
         created_at,
         updated_at
       `);
@@ -169,7 +170,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { email, password, full_name, phone, nip, jabatan, satuan_kerja, instansi, unit_id } = body;
+    const { email, password, role, full_name, phone, nip, jabatan, satuan_kerja, instansi, unit_id } = body;
 
     if (!email || !password) {
       return NextResponse.json(
@@ -193,6 +194,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Role untuk akses: user | pic | admin. Default 'user' agar bisa login; admin perlu role 'admin' untuk akses panel admin
+    const profileRole = role === 'admin' || role === 'pic' ? role : 'user';
+
     // Create profile - using insert since we're creating a new user
     // Service role key should bypass RLS policies
     const { data: profile, error: profileError } = await supabase
@@ -206,6 +210,7 @@ export async function POST(request: NextRequest) {
         jabatan,
         satuan_kerja,
         instansi,
+        role: profileRole,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       })

--- a/app/context/user-context.tsx
+++ b/app/context/user-context.tsx
@@ -59,10 +59,9 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         setIsAdmin(false)
       } else {
         setUserRole(profile.role)
-        setIsAdmin(profile.role === 'admin')
       }
 
-      // Fetch user's assigned units
+      // Fetch user's assigned units - isAdmin (superadmin) HANYA true kalau punya unit_id = 1
       const response = await fetch('/api/v1/users/units')
       
       if (response.ok) {
@@ -70,16 +69,16 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         if (result.success) {
           const units: UserUnit[] = result.data.units || []
           setUserUnits(units)
-          
-          
-          // Check if user has superadmin unit (unit_id = 1)
           const isSuperAdmin = units.some((unit: UserUnit) => unit.unit_id === 1)
           setIsAdmin(isSuperAdmin)
-          
+        } else {
+          setUserUnits([])
+          setIsAdmin(false)
         }
       } else {
         console.error('Failed to fetch user units')
         setUserUnits([])
+        setIsAdmin(false)
       }
       
     } catch (error) {

--- a/components/data-table-admin-konsultasi.tsx
+++ b/components/data-table-admin-konsultasi.tsx
@@ -2476,6 +2476,7 @@ export function DataTableAdminKonsultasi({
 	const [data, setData] = React.useState(() => initialData);
 	const [loading, setLoading] = React.useState(false);
 	const [totalCount, setTotalCount] = React.useState(initialData.length);
+	const [emptyMessage, setEmptyMessage] = React.useState<string | null>(null);
 
 	// Get current parameters from URL
 	const currentPage = parseInt(searchParams.get("page") || "1");
@@ -2618,12 +2619,14 @@ export function DataTableAdminKonsultasi({
 
 				if (!response.ok) {
 					const errorText = await response.text();
-					console.error("API Error Response:", {
-						status: response.status,
-						statusText: response.statusText,
-						errorText,
-						endpoint: apiEndpoint,
-					});
+					if (response.status !== 403) {
+						console.error("API Error Response:", {
+							status: response.status,
+							statusText: response.statusText,
+							errorText,
+							endpoint: apiEndpoint,
+						});
+					}
 					throw new Error(
 						`API Error: ${response.status} - ${response.statusText}`
 					);
@@ -2633,6 +2636,11 @@ export function DataTableAdminKonsultasi({
 				if (result.success && result.data) {
 					setData(result.data);
 					setTotalCount(result.pagination?.total || 0);
+					if (result.data.length === 0 && result.message) {
+						setEmptyMessage(result.message);
+					} else {
+						setEmptyMessage(null);
+					}
 
 					// Update URL parameters only if not skipped and not initial load
 					if (!skipURLUpdate && !initialLoadRef.current) {
@@ -2653,17 +2661,12 @@ export function DataTableAdminKonsultasi({
 					throw new Error(result.message || "Failed to fetch data");
 				}
 			} catch (error) {
-				console.error("Error fetching konsultasi data:", error);
-				console.error("Error details:", {
-					isAdmin,
-					userLoading,
-					apiEndpoint: isAdmin
-						? `/api/v1/konsultasi/admin/super`
-						: `/api/v1/konsultasi/admin/unit`,
-					error: error instanceof Error ? error.message : error,
-				});
+				const msg = error instanceof Error ? error.message : "Unknown error";
+				if (!msg.includes("403")) {
+					console.error("Error fetching konsultasi data:", error);
+				}
 				toast.error("Gagal memuat data konsultasi", {
-					description: error instanceof Error ? error.message : "Unknown error",
+					description: msg,
 				});
 			} finally {
 				setLoading(false);
@@ -2971,7 +2974,16 @@ export function DataTableAdminKonsultasi({
 																colSpan={columnsWithData.length}
 																className="h-24 text-center"
 															>
-																Tidak ada data konsultasi.
+																<div className="flex flex-col gap-1">
+																	<span>
+																		{emptyMessage || "Tidak ada data konsultasi."}
+																	</span>
+																	{emptyMessage?.includes("unit yang ditugaskan") && (
+																		<span className="text-sm text-muted-foreground">
+																			Hubungi admin untuk assign unit ke akun Anda.
+																		</span>
+																	)}
+																</div>
 															</TableCell>
 														</TableRow>
 													)}

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -19,7 +19,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { User, CreateUserData, UpdateUserData } from "@/lib/users-api";
+import { User, CreateUserData, UpdateUserData, UserRole } from "@/lib/users-api";
 import { Unit, getUnits } from "@/lib/units-api";
 import { Loader2, Building2 } from "lucide-react";
 
@@ -51,12 +51,14 @@ export function UserForm({
 					jabatan: user.jabatan || "",
 					satuan_kerja: user.satuan_kerja || "",
 					instansi: user.instansi || "",
+					role: (user.role as UserRole) || "user",
 					unit_id: user.unit_id || undefined,
 				};
 			}
 			return {
 				email: "",
 				password: "",
+				role: "user" as UserRole,
 				full_name: "",
 				phone: "",
 				nip: "",
@@ -90,6 +92,7 @@ export function UserForm({
 				jabatan: user.jabatan || "",
 				satuan_kerja: user.satuan_kerja || "",
 				instansi: user.instansi || "",
+				role: (user.role as UserRole) || "user",
 				unit_id: user.unit_id ?? undefined,
 			});
 		}
@@ -97,6 +100,7 @@ export function UserForm({
 			setFormData({
 				email: "",
 				password: "",
+				role: "user" as UserRole,
 				full_name: "",
 				phone: "",
 				nip: "",
@@ -187,6 +191,7 @@ export function UserForm({
 						? {
 								email: "",
 								password: "",
+								role: "user" as UserRole,
 								full_name: "",
 								phone: "",
 								nip: "",
@@ -262,6 +267,25 @@ export function UserForm({
 								<p className="text-sm text-red-600">{errors.password}</p>
 							)}
 						</div>
+					</div>
+
+
+					<div className="space-y-2">
+						<Label htmlFor="role">Role</Label>
+						<Select
+							value={"role" in formData ? (formData.role || "user") : "user"}
+							onValueChange={(value) => handleChange("role", value as UserRole)}
+							disabled={loading}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Pilih role" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="user">User</SelectItem>
+								<SelectItem value="pic">PIC</SelectItem>
+								<SelectItem value="admin">Admin</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 
 					<div className="grid grid-cols-2 gap-4">

--- a/components/users-data-table.tsx
+++ b/components/users-data-table.tsx
@@ -143,6 +143,20 @@ export function UsersDataTable() {
       },
     },
     {
+      accessorKey: 'role',
+      header: 'Role',
+      cell: ({ row }) => {
+        const role = row.original.role as string | undefined;
+        const label = role === 'admin' ? 'Admin' : role === 'pic' ? 'PIC' : 'User';
+        const variant = role === 'admin' ? 'default' : role === 'pic' ? 'secondary' : 'outline';
+        return (
+          <Badge variant={variant}>
+            {label}
+          </Badge>
+        );
+      },
+    },
+    {
       accessorKey: 'jabatan',
       header: 'Jabatan',
       cell: ({ row }) => {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -107,8 +107,8 @@ export async function updateSession(request: NextRequest) {
       return NextResponse.redirect(url);
     }
 
-    // Additional check for specific admin routes that require superadmin access
-    const restrictedAdminPaths = ["/admin/users", "/admin/context", "/admin/summary"];
+    // Hanya User Management dan Context yang wajib superadmin; Summary boleh untuk admin biasa (data per unit)
+    const restrictedAdminPaths = ["/admin/users", "/admin/context"];
     const isRestrictedPath = restrictedAdminPaths.some(path => 
       request.nextUrl.pathname.startsWith(path)
     );

--- a/lib/users-api.ts
+++ b/lib/users-api.ts
@@ -1,6 +1,8 @@
 // lib/users-api.ts
 import { Profile } from '@/types/profile';
 
+export type UserRole = 'user' | 'pic' | 'admin';
+
 export interface User {
   id: string;
   full_name: string | null;
@@ -10,6 +12,7 @@ export interface User {
   jabatan: string | null;
   satuan_kerja: string | null;
   instansi: string | null;
+  role?: UserRole | null;
   created_at: string;
   updated_at: string;
   unit_id?: number; // Single assigned unit ID
@@ -18,6 +21,7 @@ export interface User {
 export interface CreateUserData {
   email: string;
   password: string;
+  role?: UserRole; // user | pic | admin - default 'user' jika tidak diisi
   full_name?: string;
   phone?: string;
   nip?: string;
@@ -32,6 +36,7 @@ export interface UpdateUserData {
   phone?: string;
   email?: string;
   password?: string;
+  role?: UserRole; // user | pic | admin - untuk mengubah role (termasuk jadi admin)
   nip?: string;
   jabatan?: string;
   satuan_kerja?: string;
@@ -148,7 +153,7 @@ export const formatUserName = (user: User): string => {
 };
 
 export const formatUserRole = (user: User): string => {
-  return user.jabatan || 'No Role';
+  return user.role || user.jabatan || 'No Role';
 };
 
 export const formatUserInstitution = (user: User): string => {


### PR DESCRIPTION
## 📌 Deskripsi
Menambah fitur role user (User/PIC/Admin) di User Management, perbaikan data konsultasi untuk admin biasa, dan akses Summary untuk admin non-superadmin. Perubahan: form Create/Edit User punya dropdown Role; API create/update user menyimpan role di profiles; API unit-filtered konsultasi diperbaiki (query dua langkah) agar admin biasa bisa lihat data per unit; pesan kosong jelas saat user belum punya unit; user-context hanya set isAdmin (superadmin) setelah units load agar tidak 403; middleware mengizinkan admin biasa akses /admin/summary (data tetap filter per unit).

## 📝 Tipe Perubahan
<!-- Pilih satu atau lebih dengan menghapus tanda komentar -->
- [x] Fitur Baru 🚀
- [x] Perbaikan Bug 🐛
- [ ] Perubahan Dokumentasi 📚
- [ ] Refactor Kode 🧹
- [ ] Perubahan Konfigurasi ⚙️
- [ ] Lainnya: ....

## ✅ Checklist
<!-- Pastikan semuanya sudah dicek sebelum membuat PR -->
- [x] Kode sudah diuji dan berfungsi sesuai harapan
- [x] Tidak ada error atau bug yang tertinggal
- [x] Sudah mengikuti style guide dan konvensi penamaan
- [x] PR ini mengarah ke branch yang benar (misal: `main`, `develop`)
- [ ] Dokumentasi telah diperbarui (jika perlu)


## 📢 Catatan Tambahan
<!-- Tambahkan hal-hal penting atau konteks tambahan lainnya -->
Pastikan semua route dan halaman sudah sesuai dengan kebutuhan aplikasi admin.
Tabel profiles harus punya kolom role (user/pic/admin). Superadmin tetap satu-satunya yang bisa akses User Management dan Context; admin biasa bisa akses Summary dan Data Konsultasi (data per unit).